### PR TITLE
ci: automate deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+# adapted from https://github.com/dokku/github-action/blob/db5e3b84461e5e73c56d8b0f6a67aab0df25256c/example-workflows/simple.yml
+name: 'deploy'
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Push to dokku
+        uses: dokku/github-action@master
+        with:
+          branch: main
+          # only extracting the server address to a secret avoids leaking it in the logs
+          git_remote_url: ssh://dokku@${{ secrets.DOKKU_SERVER_ADDRESS }}/provideq
+          ssh_private_key: ${{ secrets.DOKKU_DEPLOYMENT_KEY }}


### PR DESCRIPTION
This PR adds a GitHub Workflow that deploys this application to a Dokku server automatically. The Dokku server and deployment key can be configured in the GitHub Actions secrets settings. They are currently configured to my personal server but we can change them easily at any time.