### PR TITLE
fix: make API base URL available to the browser

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
-  env: {
-    API_BASE_URL: "http://localhost:8080"
-  }
+  swcMinify: true
 }
 
 module.exports = nextConfig

--- a/src/api/ToolboxAPI.ts
+++ b/src/api/ToolboxAPI.ts
@@ -3,7 +3,7 @@ import {Solution} from "../components/solvers/Solution";
 export async function postProblem(problemType: string, content: any): Promise<Solution> {
     let returnData: Solution = { debugData: "", error: "", metaData: "", solutionData: "" };
 
-    await fetch(`${process.env.API_BASE_URL}/solve/${problemType}`, {
+    await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/solve/${problemType}`, {
         method: "POST",
         headers: {
             'Content-Type': 'application/json'


### PR DESCRIPTION
use a `NEXT_PUBLIC_` env variable instead to make it available to the browser