### PR TITLE
docs: add instructions for disabling Next.js telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository contains the web frontend for the ProvideQ toolbox.
 2. Make sure that the [Yarn package manager is enabled](https://yarnpkg.com/getting-started/install) (check with `yarn -v`)
 3. Clone this repository
 4. Install dependencies: `yarn install`
+5. Optional:
+   By default, Next.js will collect
+   [anonymous telemetry data](https://nextjs.org/telemetry).
+   You can disable the data collection using `yarn exec next telemetry disable`.
 5. Use `yarn dev` to spin up a local development server
 
 ## License


### PR DESCRIPTION
This PR adds instructions to our README file that help with disabling Next.js telemetry data collection.