### PR TITLE
Add link to API documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 ProvideQ
+Copyright (c) 2022 - 2023 ProvideQ
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ This repository contains the web frontend for the ProvideQ toolbox.
 5. Use `yarn dev` to spin up a local development server
 
 ## License
-Copyright (c) 2022 ProvideQ
+Copyright (c) 2022 - 2023 ProvideQ
 
 This project is available under the [MIT License](./LICENSE)

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,9 +30,14 @@ const Home: NextPage = () => {
           Feel free to try it out!
         </Text>
         <Text color="text" align="justify">
-          Our GitHub: <Link href="https://github.com/ProvideQ">@ProvideQ</Link>
+          Our GitHub:{' '}
+          <Link href="https://github.com/ProvideQ" color="blue.400">@ProvideQ</Link>
           <br/>
-          Contact: <Link href="mailto:provideq@lists.kit.edu">provideq@lists.kit.edu</Link>
+          API documentation:{' '}
+          <Link href={process.env.NEXT_PUBLIC_API_BASE_URL + "/swagger-ui/index.html"} color="blue.400">OpenAPI definition</Link>
+          <br/>
+          Contact:{' '}
+          <Link href="mailto:provideq@lists.kit.edu" color="blue.400">provideq@lists.kit.edu</Link>
         </Text>
 
         <Heading as="h2" size="xl" pt="10">


### PR DESCRIPTION
The link will be displayed on the front page and targets the API server configured for the website:

![image](https://github.com/ProvideQ/toolbox-web/assets/60352933/433a73ee-7bdc-4602-a7ab-84002409f92d)
