### PR TITLE
Fix: broken import in some dependency

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -35,11 +35,27 @@ jobs:
         run: yarn install
       - name: Run tests
         run: yarn test
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo (shallow)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: yarn install
+      - name: Run tests
+        run: yarn build
   deploy:
     runs-on: ubuntu-latest
     needs:
       - lint
       - test
+      - build
     if: ${{ github.ref == 'refs/heads/develop' }}
     steps:
       - name: Cloning repo

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "format": "prettier --write .",
     "test": "jest"
   },
+  "resolutions": {
+    "d3-interpolate": "2.0.1"
+  },
   "dependencies": {
     "@antv/g6": "^4.7.16",
     "@chakra-ui/react": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2831,10 +2831,10 @@ csstype@^3.0.11, csstype@^3.0.2, csstype@^3.0.8:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-"d3-color@1 - 3":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
-  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+"d3-color@1 - 2":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
+  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
 
 "d3-dispatch@1 - 2":
   version "2.0.0"
@@ -2855,12 +2855,12 @@ d3-force@^2.0.1, d3-force@^2.1.1:
     d3-quadtree "1 - 2"
     d3-timer "1 - 2"
 
-d3-interpolate@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
-  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+d3-interpolate@2.0.1, d3-interpolate@^3.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-2.0.1.tgz#98be499cfb8a3b94d4ff616900501a64abc91163"
+  integrity sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==
   dependencies:
-    d3-color "1 - 3"
+    d3-color "1 - 2"
 
 "d3-quadtree@1 - 2", d3-quadtree@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Commit c83fcba81ca328d9ccd0c18c9d336575ed52ebc6 (yarn upgrade) introduced a build error that previously wasn't caught by our CI pipeline. This PR makes sure that our CI pipeline will catch build errors from now on.

However, the surfacing problem still needs to be solved. @Elscrux do you have any idea how to fix this? Reverting c83fcba81ca328d9ccd0c18c9d336575ed52ebc6 would certainly work, but this can't be our best solution...