### PR TITLE
fix: use standardized API routes

### DIFF
--- a/src/components/solvers/ProgressHandler.tsx
+++ b/src/components/solvers/ProgressHandler.tsx
@@ -38,8 +38,10 @@ export const ProgressHandler = <T extends {}>(
 
     setSolveRequest(newSolveRequest);
     Promise.all(
-      props.problemTypes.map(problemType => postProblem(problemType, newSolveRequest))
-    ).then(solutions => {
+      props.problemTypes.map((problemType) =>
+        postProblem(problemType, newSolveRequest)
+      )
+    ).then((solutions) => {
       setSolutions(solutions);
       setFinished(true);
     });
@@ -52,18 +54,20 @@ export const ProgressHandler = <T extends {}>(
           <Center>
             <GoButton clicked={startSolving} />
           </Center>
-          {props.problemTypes.map(problemType => <SolverPicker
-            key={problemType}
-            problemUrlFragment={problemType}
-            setSolveRequest={solverChoice => {
-              setSolveRequest({
-                ...solveRequest,
-                requestedSolverId: solverChoice.requestedSolverId,
-                requestedSubSolveRequests:
-                  solveRequest.requestedSubSolveRequests
-              })
-            }}
-          />)}
+          {props.problemTypes.map((problemType) => (
+            <SolverPicker
+              key={problemType}
+              problemUrlFragment={problemType}
+              setSolveRequest={(solverChoice) => {
+                setSolveRequest({
+                  ...solveRequest,
+                  requestedSolverId: solverChoice.requestedSolverId,
+                  requestedSubSolveRequests:
+                    solveRequest.requestedSubSolveRequests,
+                });
+              }}
+            />
+          ))}
         </VStack>
       ) : null}
 

--- a/src/components/solvers/SolutionView.tsx
+++ b/src/components/solvers/SolutionView.tsx
@@ -33,7 +33,8 @@ const OutputSection = (props: { title: string; content: any[] }) => (
           {contentChunk !== null && contentChunk !== undefined ? (
             <Code width="100%" padding="1rem">
               <pre style={{ overflowX: "auto" }}>
-                {typeof contentChunk === "string" || contentChunk instanceof String
+                {typeof contentChunk === "string" ||
+                contentChunk instanceof String
                   ? contentChunk
                   : JSON.stringify(contentChunk, null, "\t")}
               </pre>

--- a/src/components/solvers/SolutionView.tsx
+++ b/src/components/solvers/SolutionView.tsx
@@ -27,15 +27,15 @@ const OutputSection = (props: { title: string; content: any[] }) => (
         <AccordionIcon />
       </AccordionButton>
     </h2>
-    {props.content.map((c) => {
+    {props.content.map((contentChunk, chunkIndex) => {
       return (
-        <AccordionPanel pb="4" key={c}>
-          {c !== null && c !== undefined ? (
+        <AccordionPanel pb="4" key={chunkIndex}>
+          {contentChunk !== null && contentChunk !== undefined ? (
             <Code width="100%" padding="1rem">
               <pre style={{ overflowX: "auto" }}>
-                {typeof c === "string" || c instanceof String
-                  ? c
-                  : JSON.stringify(c, null, "\t")}
+                {typeof contentChunk === "string" || contentChunk instanceof String
+                  ? contentChunk
+                  : JSON.stringify(contentChunk, null, "\t")}
               </pre>
             </Code>
           ) : (

--- a/src/pages/solve/FeatureModelAnomaly.tsx
+++ b/src/pages/solve/FeatureModelAnomaly.tsx
@@ -41,7 +41,7 @@ const FeatureModelAnomaly: NextPage = () => {
           <Divider />
 
           <ProgressHandler
-            problemTypes={selectedAnomalies.map(option => option.value)}
+            problemTypes={selectedAnomalies.map((option) => option.value)}
             problemInput={uvl}
           />
         </VStack>

--- a/src/pages/solve/FeatureModelAnomaly.tsx
+++ b/src/pages/solve/FeatureModelAnomaly.tsx
@@ -8,19 +8,11 @@ import { TextInputMask } from "../../components/solvers/TextInputMask";
 const anomalies: Option[] = [
   {
     label: "Void Feature Model",
-    value: "feature-model/anomaly/void",
+    value: "feature-model-anomaly-void",
   },
   {
     label: "Dead Features",
-    value: "feature-model/anomaly/dead",
-  },
-  {
-    label: "False-Optional Features",
-    value: "feature-model/anomaly/false-optional",
-  },
-  {
-    label: "Redundant Constraints",
-    value: "feature-model/anomaly/redundant-constraints",
+    value: "feature-model-anomaly-dead",
   },
 ];
 
@@ -49,8 +41,7 @@ const FeatureModelAnomaly: NextPage = () => {
           <Divider />
 
           <ProgressHandler
-            explicitSolvers={selectedAnomalies.map((a) => a.value)}
-            problemUrlFragment="feature-model/anomaly"
+            problemTypes={selectedAnomalies.map(option => option.value)}
             problemInput={uvl}
           />
         </VStack>

--- a/src/pages/solve/MaxCut.tsx
+++ b/src/pages/solve/MaxCut.tsx
@@ -35,7 +35,7 @@ const MaxCut: NextPage = () => {
 
           <Divider />
           <ProgressHandler
-            problemUrlFragment="max-cut"
+            problemTypes={["max-cut"]}
             problemInput={graphString}
           />
         </Container>

--- a/src/pages/solve/SAT.tsx
+++ b/src/pages/solve/SAT.tsx
@@ -70,7 +70,7 @@ const SAT: NextPage = () => {
         />
         <Divider />
         <ProgressHandler
-          problemUrlFragment="sat"
+          problemTypes={["sat"]}
           problemInput={logicalExpressionString}
         />
       </Main>


### PR DESCRIPTION
https://github.com/ProvideQ/toolbox-server/pull/40 standardized the API route naming which broke our API client. This PR fixes that and adds solver selection dropdowns for each of the problem types that are supposed to be solved simultaneously.