### PR TITLE
Remove logical expression parsing

### DIFF
--- a/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
+++ b/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
@@ -1,6 +1,5 @@
 import each from "jest-each";
 import { DimacsParser } from "../../../src/converter/dimacs/DimacsParser";
-import { LogicalExpressionParser } from "../../../src/converter/dimacs/LogicalExpressionParser";
 import { regexBlank } from "../../../src/converter/dimacs/Syntax/CommonSyntax";
 import { regexComment } from "../../../src/converter/dimacs/Syntax/DimacsSyntax";
 import { regexNOT } from "../../../src/converter/dimacs/Syntax/LogicalExpressionSyntax";

--- a/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
+++ b/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
@@ -21,7 +21,7 @@ describe("Parsing", () => {
   let dimacsParser = new DimacsParser();
   let logicalExpressionParser = new LogicalExpressionParser();
 
-  each([
+  /*each([
     [
       "((1 or 2 or not 3) and (!4 and (not 5 and 6)) and 3 and (7 or 2))",
       "c First comment\nc Some Comment\nc 1 => 1\np sat 7\n*(+( 1  2  -3 )*( -4 *( -5  6 )) 3 +( 7  2 ))",
@@ -48,7 +48,7 @@ describe("Parsing", () => {
         logicalExpression
       );
     }
-  );
+  );*/
 
   each([
     [

--- a/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
+++ b/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
@@ -19,36 +19,6 @@ function isEquivalentDimacs(f1: string, f2: string) {
 
 describe("Parsing", () => {
   let dimacsParser = new DimacsParser();
-  let logicalExpressionParser = new LogicalExpressionParser();
-
-  /*each([
-    [
-      "((1 or 2 or not 3) and (!4 and (not 5 and 6)) and 3 and (7 or 2))",
-      "c First comment\nc Some Comment\nc 1 => 1\np sat 7\n*(+( 1  2  -3 )*( -4 *( -5  6 )) 3 +( 7  2 ))",
-    ],
-    [
-      "(1 or (2 and 3) or (((1 and 4) or 5) and 6))",
-      "p sat 6\n+(1 *(2  3)*(+(*(1  4) 5) 6))",
-    ],
-    [
-      "(((1 and not 2 and 3 and 4) or 3) and 5)",
-      "c Sample DIMACS .sat file\np sat 5\n*(+(*(1  -2  3  4) 3) 5)",
-    ],
-    ["((1 and not 2) or 3)", "p sat 3\n+(*(1 -2) 3)"],
-    ["((1 and 2) or not 3)", "p sat 3\n+(*(1 2) -3)"],
-  ]).test(
-    "parsing bi-directional",
-    (logicalExpression: string, dimacs: string) => {
-      isEquivalentDimacs(
-        logicalExpressionParser.parseDimacs(logicalExpression),
-        dimacs
-      );
-      isEquivalentLogicalExpression(
-        dimacsParser.parseLogicalExpression(dimacs),
-        logicalExpression
-      );
-    }
-  );*/
 
   each([
     [

--- a/src/components/solvers/SAT/prism-SAT.ts
+++ b/src/components/solvers/SAT/prism-SAT.ts
@@ -1,7 +1,7 @@
 import { regexVariable } from "../../../converter/dimacs/Syntax/CommonSyntax";
 import {
   regexAND,
-  regexNOTVariable,
+  regexNOT,
   regexOR,
 } from "../../../converter/dimacs/Syntax/LogicalExpressionSyntax";
 
@@ -16,7 +16,7 @@ export const SAT_language = {
   },
   "SAT-punctuation": /[()]/,
   negation: {
-    pattern: regexNOTVariable,
+    pattern: regexNOT,
     alias: "string",
   },
   "SAT-variable": {

--- a/src/converter/dimacs/LogicalExpressionParser.ts
+++ b/src/converter/dimacs/LogicalExpressionParser.ts
@@ -21,17 +21,9 @@ const rules = [
   variableRule,
   blankRule,
 ];
-const rulesNegation = [negateRule, variableRule, blankRule];
-
-interface LeveledToken {
-  level: number;
-  token: Token;
-}
 
 export class LogicalExpressionParser {
   private lex: Lexer = new Lexer(rules);
-  private lexNegation: Lexer = new Lexer(rulesNegation);
-  private output: string = "";
 
   /**
    * Converts a logical expression to an expression in dimacs sat format
@@ -39,31 +31,12 @@ export class LogicalExpressionParser {
    * @param logicalExpression {string} logical expression
    * @returns {string} formula in dimacs sat format of the input
    */
-  public parseDimacs(logicalExpression: string): string {
-    this.output = "";
-
+  public validateLogicalExpression(logicalExpression: string): string[] {
     let tokens = this.lex.tokenize(logicalExpression);
-    if (tokens.length == 0) return this.output;
+    if (tokens.length == 0) return [];
 
     //Verify formula integrity
-    let errors = this.verifyTokens(tokens);
-    if (errors.length > 0) {
-      let errorStr = "";
-      for (let error of errors) errorStr += error + "\n";
-
-      throw new Error(errorStr);
-    }
-
-    //Handle variable comments and program start
-    let variables = this.convertVariables(tokens);
-    variables.forEach((num, str, _) => {
-      this.output += `c ${num} ${TokenName.variableAssignment} ${str}\n`;
-    });
-    this.output += `p sat ${variables.size}\n`;
-
-    this.parseFormula(tokens);
-
-    return this.output;
+    return this.verifyTokens(tokens);
   }
 
   private verifyTokens(tokens: Token[]): string[] {
@@ -120,174 +93,5 @@ export class LogicalExpressionParser {
     }
 
     return errors;
-  }
-  /**
-   * Converts any negative variable's negative prefix
-   * Converts all variables to numbers
-   * @param tokens {Token[]} array of tokens to search for variables
-   * @returns {Map<string, number>} variables mapped to their number representation
-   */
-  private convertVariables(tokens: Token[]): Map<string, number> {
-    let variables = new Map<string, number>();
-    const addToMap = (str: string): number => {
-      let number = variables.get(str);
-      if (number == undefined) {
-        number = variables.size + 1;
-        variables.set(str, number);
-      }
-
-      return number;
-    };
-
-    for (let i = 0; i < tokens.length; i++) {
-      switch (tokens[i].name) {
-        case TokenName.variable:
-          tokens[i].lexeme = addToMap(tokens[i].lexeme).toString();
-          break;
-        case TokenName.negatedVariable:
-          let negTokens = this.lexNegation.tokenize(tokens[i].lexeme);
-          if (negTokens.length != 2)
-            throw new Error(
-              "Can't parse negated variables that don't have two tokens"
-            );
-
-          let negToken = negTokens[1] as Token;
-          let varNumber = addToMap(negToken.lexeme);
-
-          //Replace negated variable with dimacs negative variable syntax
-          negToken.lexeme = `-${varNumber}`;
-          tokens[i] = negToken;
-          break;
-      }
-    }
-
-    return variables;
-  }
-
-  private getLeveledTokens(tokens: Token[]): LeveledToken[] {
-    let leveledTokens: LeveledToken[] = [];
-    let curLevel = 0;
-
-    for (let token of tokens) {
-      switch (token.name) {
-        case TokenName.open:
-          curLevel++;
-          break;
-        case TokenName.close:
-          curLevel--;
-          break;
-        default:
-          leveledTokens.push({ token: token, level: curLevel });
-          break;
-      }
-    }
-
-    return leveledTokens;
-  }
-
-  private parseFormula(tokens: Token[]) {
-    let leveledTokens = this.getLeveledTokens(tokens);
-
-    //Start recursive parsing of formula starting with or
-    this.processOR(leveledTokens);
-  }
-
-  private getOperatorPositions(
-    tokens: LeveledToken[],
-    operator: string,
-    level: number
-  ): number[] {
-    let positions: number[] = [];
-    for (let i = 0; i < tokens.length; i++) {
-      let token = tokens[i];
-      switch (token.token.name) {
-        case operator:
-          if (token.level == level) positions.push(i);
-          break;
-        default:
-          break;
-      }
-    }
-
-    //Always add token length
-    positions.push(tokens.length);
-
-    return positions;
-  }
-
-  private getMinLevel(tokens: LeveledToken[]): number {
-    let minLevel = undefined;
-
-    for (const token of tokens) {
-      if (minLevel == undefined || token.level < minLevel) {
-        minLevel = token.level;
-      }
-    }
-
-    return minLevel ?? -1;
-  }
-
-  private processAND(tokens: LeveledToken[]): LeveledToken[] {
-    if (tokens.length < 2) {
-      this.output += ` ${tokens[0].token.lexeme} `;
-      return tokens;
-    }
-
-    let level = this.getMinLevel(tokens);
-    let operatorPositions = this.getOperatorPositions(
-      tokens,
-      TokenName.and,
-      level
-    );
-    if (operatorPositions.length == 1) return this.processOR(tokens);
-
-    let returnTokens: LeveledToken[] = [];
-    let lastOr = -1;
-
-    this.output += `*(`;
-    for (let pos of operatorPositions) {
-      let before = tokens.slice(lastOr + 1, pos);
-      lastOr = pos;
-
-      let processedBefore = this.processOR(before);
-      returnTokens.push(...processedBefore);
-    }
-    this.output += `)`;
-
-    return returnTokens;
-  }
-
-  private processOR(tokens: LeveledToken[]): LeveledToken[] {
-    if (tokens.length < 2) {
-      this.output += ` ${tokens[0].token.lexeme} `;
-      return tokens;
-    }
-
-    let level = this.getMinLevel(tokens);
-    let operatorPositions = this.getOperatorPositions(
-      tokens,
-      TokenName.or,
-      level
-    );
-    if (operatorPositions.length == 1) return this.processAND(tokens);
-
-    let returnTokens: LeveledToken[] = [];
-    let lastOr = -1;
-
-    if (operatorPositions.length > 1) this.output += `+(`;
-    for (let pos of operatorPositions) {
-      let before = tokens.slice(lastOr + 1, pos);
-      lastOr = pos;
-
-      //Start processing nested expressions with OR
-      let processedBefore =
-        before[0].level != level
-          ? this.processOR(before)
-          : this.processAND(before);
-      returnTokens.push(...processedBefore);
-    }
-    if (operatorPositions.length > 1) this.output += `)`;
-
-    return returnTokens;
   }
 }

--- a/src/converter/dimacs/LogicalExpressionParser.ts
+++ b/src/converter/dimacs/LogicalExpressionParser.ts
@@ -5,19 +5,14 @@ import {
   TokenName,
   variableRule,
 } from "./Syntax/CommonSyntax";
-import {
-  andRule,
-  negatedVariableRule,
-  negateRule,
-  orRule,
-} from "./Syntax/LogicalExpressionSyntax";
+import { andRule, negateRule, orRule } from "./Syntax/LogicalExpressionSyntax";
 
 // the order is important - tokens are applied from first to last
 const rules = [
   ...parenthesesRule,
   orRule,
   andRule,
-  negatedVariableRule,
+  negateRule,
   variableRule,
   blankRule,
 ];

--- a/src/converter/dimacs/LogicalExpressionValidator.ts
+++ b/src/converter/dimacs/LogicalExpressionValidator.ts
@@ -107,10 +107,6 @@ export class LogicalExpressionValidator {
       wasNegate = token.name == TokenName.negate;
     }
 
-    if (errors.length > 0) {
-      return errors;
-    } else {
-      return null;
-    }
+    return errors;
   }
 }

--- a/src/converter/dimacs/LogicalExpressionValidator.ts
+++ b/src/converter/dimacs/LogicalExpressionValidator.ts
@@ -23,9 +23,9 @@ export class LogicalExpressionValidator {
   /**
    * Validates a logical expression
    * @param logicalExpression {string} logical expression
-   * @returns {string[]} an array of errors. If empty, the logical expression is valid.
+   * @returns {string[]} an array of errors, or null if there are none.
    */
-  public validateLogicalExpression(logicalExpression: string): string[] {
+  public validateLogicalExpression(logicalExpression: string): string[] | null {
     let tokens = this.lex.tokenize(logicalExpression);
     if (tokens.length == 0) return [];
 
@@ -33,7 +33,7 @@ export class LogicalExpressionValidator {
     return this.verifyTokens(tokens);
   }
 
-  private verifyTokens(tokens: Token[]): string[] {
+  private verifyTokens(tokens: Token[]): string[] | null {
     let errors: string[] = [];
     let wasOperator = false;
     let wasVariable = false;
@@ -107,6 +107,10 @@ export class LogicalExpressionValidator {
       wasNegate = token.name == TokenName.negate;
     }
 
-    return errors;
+    if (errors.length > 0) {
+      return errors;
+    } else {
+      return null;
+    }
   }
 }

--- a/src/converter/dimacs/LogicalExpressionValidator.ts
+++ b/src/converter/dimacs/LogicalExpressionValidator.ts
@@ -17,14 +17,13 @@ const rules = [
   blankRule,
 ];
 
-export class LogicalExpressionParser {
+export class LogicalExpressionValidator {
   private lex: Lexer = new Lexer(rules);
 
   /**
-   * Converts a logical expression to an expression in dimacs sat format
-   * dimacs sat format: https://www.domagoj-babic.com/uploads/ResearchProjects/Spear/dimacs-cnf.pdf
+   * Validates a logical expression
    * @param logicalExpression {string} logical expression
-   * @returns {string} formula in dimacs sat format of the input
+   * @returns {string[]} an array of errors. If empty, the logical expression is valid.
    */
   public validateLogicalExpression(logicalExpression: string): string[] {
     let tokens = this.lex.tokenize(logicalExpression);

--- a/src/converter/dimacs/Syntax/CommonSyntax.ts
+++ b/src/converter/dimacs/Syntax/CommonSyntax.ts
@@ -7,12 +7,10 @@ export enum TokenName {
   open = "open",
   close = "close",
   variable = "variable",
-  negatedVariable = "negatedVariable",
   variableAssignment = "=>",
 }
 
-export const variableRegexPart = "(?:[A-z]|\\d)+";
-export const regexVariable = new RegExp(variableRegexPart);
+export const regexVariable = /(?:[A-z]|\d)+/;
 export const regexBlank = /\s+/g;
 
 export const variableRule = new Rule({

--- a/src/converter/dimacs/Syntax/LogicalExpressionSyntax.ts
+++ b/src/converter/dimacs/Syntax/LogicalExpressionSyntax.ts
@@ -1,23 +1,13 @@
 import { Rule } from "@jlguenego/lexer";
-import { TokenName, variableRegexPart } from "./CommonSyntax";
+import { TokenName } from "./CommonSyntax";
 
-export const negateRegexPart = "(?:(?:not|NOT)\\s+|(?:!\\s*))";
-
-export const regexAND = /(?:&|and|AND) /;
-export const regexOR = /(?:\||or|OR) /;
-export const regexNOT = new RegExp(negateRegexPart, "g");
-export const regexNOTVariable = new RegExp(
-  `${negateRegexPart}\\s*${variableRegexPart}`
-);
+export const regexAND = /(?:&|and|AND)\b/;
+export const regexOR = /(?:\||or|OR)\b/;
+export const regexNOT = /not|NOT|!/g;
 
 export const negateRule = new Rule({
   name: TokenName.negate,
   pattern: regexNOT,
-});
-
-export const negatedVariableRule = new Rule({
-  name: TokenName.negatedVariable,
-  pattern: regexNOTVariable,
 });
 
 export const andRule = new Rule({

--- a/src/pages/solve/SAT.tsx
+++ b/src/pages/solve/SAT.tsx
@@ -7,10 +7,10 @@ import { Layout } from "../../components/layout/Layout";
 import { EditorControls } from "../../components/solvers/EditorControls";
 import { ProgressHandler } from "../../components/solvers/ProgressHandler";
 import { TextArea } from "../../components/solvers/SAT/TextArea";
-import { LogicalExpressionParser } from "../../converter/dimacs/LogicalExpressionParser";
+import { LogicalExpressionValidator } from "../../converter/dimacs/LogicalExpressionValidator";
 
 const SAT: NextPage = () => {
-  const logicalExpressionParser = new LogicalExpressionParser();
+  const logicalExpressionParser = new LogicalExpressionValidator();
 
   const [logicalExpressionString, setLogicalExpressionString] = useState("");
   const [errorString, setErrorString] = useState("");

--- a/src/pages/solve/SAT.tsx
+++ b/src/pages/solve/SAT.tsx
@@ -50,7 +50,7 @@ const SAT: NextPage = () => {
             value.toString()
           );
 
-          if (errors.length > 0) {
+          if (errors) {
             setErrorString(errors.toString());
           } else {
             setErrorString("");

--- a/src/pages/solve/SAT.tsx
+++ b/src/pages/solve/SAT.tsx
@@ -10,7 +10,7 @@ import { TextArea } from "../../components/solvers/SAT/TextArea";
 import { LogicalExpressionValidator } from "../../converter/dimacs/LogicalExpressionValidator";
 
 const SAT: NextPage = () => {
-  const logicalExpressionParser = new LogicalExpressionValidator();
+  const logicalExpressionValidator = new LogicalExpressionValidator();
 
   const [logicalExpressionString, setLogicalExpressionString] = useState("");
   const [errorString, setErrorString] = useState("");
@@ -46,7 +46,7 @@ const SAT: NextPage = () => {
         setProblemString={(value) => {
           setLogicalExpressionString(value);
 
-          let errors = logicalExpressionParser.validateLogicalExpression(
+          let errors = logicalExpressionValidator.validateLogicalExpression(
             value.toString()
           );
 

--- a/src/pages/solve/SAT.tsx
+++ b/src/pages/solve/SAT.tsx
@@ -46,11 +46,14 @@ const SAT: NextPage = () => {
         setProblemString={(value) => {
           setLogicalExpressionString(value);
 
-          try {
-            logicalExpressionParser.parseDimacs(value.toString());
+          let errors = logicalExpressionParser.validateLogicalExpression(
+            value.toString()
+          );
+
+          if (errors.length > 0) {
+            setErrorString(errors.toString());
+          } else {
             setErrorString("");
-          } catch (e: any) {
-            setErrorString(e.message);
           }
         }}
       />


### PR DESCRIPTION
Fixing the bug that caused formulas like `not (something)` to be displayed in correctly.
The dimacs parser didn't support this change out of the box, so I removed it as we no longer need it.