### PR TITLE
ci: organize imports with prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+    "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,3 @@
 {
-    "plugins": ["prettier-plugin-organize-imports"]
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
+++ b/__tests__/converter/dimacs/DimacsLogicalExpression.spec.ts
@@ -1,8 +1,8 @@
 import each from "jest-each";
-import { regexBlank } from "../../../src/converter/dimacs/Syntax/CommonSyntax";
 import { DimacsParser } from "../../../src/converter/dimacs/DimacsParser";
-import { regexComment } from "../../../src/converter/dimacs/Syntax/DimacsSyntax";
 import { LogicalExpressionParser } from "../../../src/converter/dimacs/LogicalExpressionParser";
+import { regexBlank } from "../../../src/converter/dimacs/Syntax/CommonSyntax";
+import { regexComment } from "../../../src/converter/dimacs/Syntax/DimacsSyntax";
 import { regexNOT } from "../../../src/converter/dimacs/Syntax/LogicalExpressionSyntax";
 
 function isEquivalentLogicalExpression(f1: string, f2: string) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jest": "^29.1.1",
     "jest-environment-jsdom": "^29.1.1",
     "prettier": "2.8.8",
+    "prettier-plugin-organize-imports": "^3.2.4",
     "typescript": "4.8.2"
   }
 }

--- a/src/api/ToolboxAPI.ts
+++ b/src/api/ToolboxAPI.ts
@@ -1,9 +1,9 @@
 import { MetaSolverSetting } from "./data-model/MetaSolverSettings";
-import { SubRoutineDefinition } from "./data-model/SubRoutineDefinition";
 import { ProblemSolver } from "./data-model/ProblemSolver";
 import { Solution } from "./data-model/Solution";
 import { SolutionStatus } from "./data-model/SolutionStatus";
 import { SolveRequest } from "./data-model/SolveRequest";
+import { SubRoutineDefinition } from "./data-model/SubRoutineDefinition";
 
 /**
  * Getter for the base url of the toolbox API.

--- a/src/components/landing-page/ProblemCard.tsx
+++ b/src/components/landing-page/ProblemCard.tsx
@@ -1,4 +1,4 @@
-import { LinkBox, LinkOverlay, Box, Image, Badge } from "@chakra-ui/react";
+import { Badge, Box, LinkBox, LinkOverlay } from "@chakra-ui/react";
 import NextLink from "next/link";
 
 interface ProblemCardProps {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,9 +1,9 @@
-import { ReactElement, ReactNode } from "react";
+import { Spacer } from "@chakra-ui/react";
+import { ReactNode } from "react";
+import { Container } from "../Container";
 import { Hero } from "../landing-page/Hero";
 import { Main } from "../Main";
-import { Container } from "../Container";
 import { Footer } from "./Footer";
-import { Spacer } from "@chakra-ui/react";
 
 export const Layout = (props: { children: ReactNode }) => (
   <Container minHeight="100vh">

--- a/src/components/solvers/EditorControls.tsx
+++ b/src/components/solvers/EditorControls.tsx
@@ -6,8 +6,8 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import { TbDownload, TbHelp, TbUpload } from "react-icons/tb";
-import { chooseFile } from "./FileInput";
 import { baseUrl } from "../../api/ToolboxAPI";
+import { chooseFile } from "./FileInput";
 
 export interface EditorControlsProps {
   /**

--- a/src/components/solvers/FileInput.tsx
+++ b/src/components/solvers/FileInput.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export async function chooseFile(
   multiple?: boolean,
   accept?: string

--- a/src/components/solvers/Graph/GraphArea.tsx
+++ b/src/components/solvers/Graph/GraphArea.tsx
@@ -1,6 +1,6 @@
-import { Box, Center, Container, Select, Spacer } from "@chakra-ui/react";
-import React, { useEffect, useRef, useState } from "react";
 import G6, { Graph, GraphData } from "@antv/g6";
+import { Box, Center, Container, Select, Spacer } from "@chakra-ui/react";
+import { useEffect, useRef, useState } from "react";
 
 interface GraphAreaProps {
   graphData: GraphData;

--- a/src/components/solvers/ProgressHandler.tsx
+++ b/src/components/solvers/ProgressHandler.tsx
@@ -1,11 +1,11 @@
-import { Box, Center, HStack, VStack } from "@chakra-ui/react";
-import React, { useState } from "react";
-import { GoButton } from "./buttons/GoButton";
-import { postProblem } from "../../api/ToolboxAPI";
-import { SolutionView } from "./SolutionView";
-import { Container } from "../Container";
+import { Box, Center, HStack } from "@chakra-ui/react";
+import { useState } from "react";
 import { Solution } from "../../api/data-model/Solution";
 import { SolveRequest } from "../../api/data-model/SolveRequest";
+import { postProblem } from "../../api/ToolboxAPI";
+import { Container } from "../Container";
+import { GoButton } from "./buttons/GoButton";
+import { SolutionView } from "./SolutionView";
 import { SolverPicker } from "./SolverPicker";
 
 export interface ProgressHandlerProps<T> {

--- a/src/components/solvers/SAT/TextArea.tsx
+++ b/src/components/solvers/SAT/TextArea.tsx
@@ -1,8 +1,8 @@
+import { Box } from "@chakra-ui/react";
+import { highlight } from "prismjs";
 import "prismjs/themes/prism-solarizedlight.css"; //TODO: use custom styling
 import React from "react";
 import Editor from "react-simple-code-editor";
-import { highlight } from "prismjs";
-import { Box, Container } from "@chakra-ui/react";
 import { SAT_language } from "./prism-SAT";
 
 interface TextAreaProps {

--- a/src/components/solvers/SettingsView.tsx
+++ b/src/components/solvers/SettingsView.tsx
@@ -1,27 +1,27 @@
 import {
-  Container,
-  Slider,
-  Textarea,
-  Checkbox,
-  Select,
-  SliderTrack,
-  SliderFilledTrack,
-  Text,
-  SliderThumb,
-  SliderMark,
-  VStack,
   Box,
+  Checkbox,
+  Container,
+  Select,
+  Slider,
+  SliderFilledTrack,
+  SliderMark,
+  SliderThumb,
+  SliderTrack,
+  Text,
+  Textarea,
+  VStack,
 } from "@chakra-ui/react";
-import React, { useEffect, useState } from "react";
-import { fetchMetaSolverSettings } from "../../api/ToolboxAPI";
+import { useEffect, useState } from "react";
 import {
-  RangeSetting,
   CheckboxSetting,
-  TextSetting,
-  SelectSetting,
   MetaSolverSetting,
   MetaSolverSettingType,
+  RangeSetting,
+  SelectSetting,
+  TextSetting,
 } from "../../api/data-model/MetaSolverSettings";
+import { fetchMetaSolverSettings } from "../../api/ToolboxAPI";
 
 interface SettingsViewProps {
   problemType: string;

--- a/src/components/solvers/SolutionView.tsx
+++ b/src/components/solvers/SolutionView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Accordion,
   AccordionButton,
@@ -9,8 +8,8 @@ import {
   Code,
   Spinner,
 } from "@chakra-ui/react";
-import { Container } from "../Container";
 import { Solution } from "../../api/data-model/Solution";
+import { Container } from "../Container";
 
 export interface SolutionViewProps {
   finished: boolean;

--- a/src/components/solvers/SolverPicker.tsx
+++ b/src/components/solvers/SolverPicker.tsx
@@ -1,9 +1,9 @@
 import { Box, Container, Select, Text, Tooltip } from "@chakra-ui/react";
-import React, { ChangeEvent, useEffect, useState } from "react";
-import { fetchSolvers, fetchSubRoutines } from "../../api/ToolboxAPI";
-import { SubRoutineDefinition } from "../../api/data-model/SubRoutineDefinition";
+import { ChangeEvent, useEffect, useState } from "react";
 import { ProblemSolver } from "../../api/data-model/ProblemSolver";
 import { SolverChoice } from "../../api/data-model/SolveRequest";
+import { SubRoutineDefinition } from "../../api/data-model/SubRoutineDefinition";
+import { fetchSolvers, fetchSubRoutines } from "../../api/ToolboxAPI";
 import { SettingsView } from "./SettingsView";
 
 export interface SolverPickerProps {

--- a/src/components/solvers/TextInputMask.tsx
+++ b/src/components/solvers/TextInputMask.tsx
@@ -1,9 +1,7 @@
-import { Divider, Text, Textarea } from "@chakra-ui/react";
+import { Divider, Textarea } from "@chakra-ui/react";
 import Head from "next/head";
-import React, { ReactElement, useState } from "react";
+import { ReactElement, useState } from "react";
 import { Container } from "../Container";
-import { Main } from "../Main";
-import { Help } from "./SAT/Help";
 import { EditorControls } from "./EditorControls";
 
 export interface TextInputMaskProperties {

--- a/src/components/solvers/buttons/GoButton.tsx
+++ b/src/components/solvers/buttons/GoButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip, Flex } from "@chakra-ui/react";
+import { Button, Flex, Tooltip } from "@chakra-ui/react";
 import { MouseEventHandler } from "react";
 
 interface GoButtonProps {

--- a/src/converter/dimacs/DimacsParser.ts
+++ b/src/converter/dimacs/DimacsParser.ts
@@ -1,5 +1,12 @@
 import { Lexer, Token } from "@jlguenego/lexer";
 import {
+  blankRule,
+  parenthesesRule,
+  regexBlank,
+  TokenName,
+  variableRule,
+} from "./Syntax/CommonSyntax";
+import {
   andRule,
   commentRule,
   negateRule,
@@ -10,13 +17,6 @@ import {
   sat,
   startKeywords,
 } from "./Syntax/DimacsSyntax";
-import {
-  TokenName,
-  parenthesesRule,
-  variableRule,
-  blankRule,
-  regexBlank,
-} from "./Syntax/CommonSyntax";
 
 // the order is important - tokens are applied from first to last
 const rules = [

--- a/src/converter/dimacs/LogicalExpressionParser.ts
+++ b/src/converter/dimacs/LogicalExpressionParser.ts
@@ -1,9 +1,9 @@
 import { Lexer, Token } from "@jlguenego/lexer";
 import {
-  TokenName,
-  parenthesesRule,
-  variableRule,
   blankRule,
+  parenthesesRule,
+  TokenName,
+  variableRule,
 } from "./Syntax/CommonSyntax";
 import {
   andRule,

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
-import type { AppProps } from "next/app";
 import { ChakraProvider } from "@chakra-ui/react";
+import type { AppProps } from "next/app";
 import theme from "../theme";
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,5 @@
-import NextDocument, { Head, Html, Main, NextScript } from "next/document";
 import { ColorModeScript } from "@chakra-ui/react";
+import NextDocument, { Head, Html, Main, NextScript } from "next/document";
 import theme from "../theme";
 
 export default class Document extends NextDocument {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,9 @@
+import { Heading, Link, Text } from "@chakra-ui/react";
 import type { NextPage } from "next";
 import Head from "next/head";
-import { Text, Heading, Link } from "@chakra-ui/react";
+import { baseUrl } from "../api/ToolboxAPI";
 import { ProblemChooser } from "../components/landing-page/ProblemChooser";
 import { Layout } from "../components/layout/Layout";
-import { baseUrl } from "../api/ToolboxAPI";
 
 const Home: NextPage = () => {
   return (

--- a/src/pages/solve/FeatureModelAnomaly.tsx
+++ b/src/pages/solve/FeatureModelAnomaly.tsx
@@ -2,19 +2,17 @@ import {
   Box,
   Divider,
   Heading,
-  List,
   ListItem,
-  Spacer,
   Text,
   UnorderedList,
   VStack,
 } from "@chakra-ui/react";
 import { NextPage } from "next";
-import React, { useState } from "react";
+import { useState } from "react";
 import { MultiSelect, Option } from "react-multi-select-component";
+import { Layout } from "../../components/layout/Layout";
 import { ProgressHandler } from "../../components/solvers/ProgressHandler";
 import { TextInputMask } from "../../components/solvers/TextInputMask";
-import { Layout } from "../../components/layout/Layout";
 
 const anomalies: Option[] = [
   {

--- a/src/pages/solve/MaxCut.tsx
+++ b/src/pages/solve/MaxCut.tsx
@@ -8,13 +8,13 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { NextPage } from "next";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Container } from "../../components/Container";
+import { Layout } from "../../components/layout/Layout";
 import { GraphArea } from "../../components/solvers/Graph/GraphArea";
 import { ProgressHandler } from "../../components/solvers/ProgressHandler";
 import { TextInputMask } from "../../components/solvers/TextInputMask";
 import { parseGML } from "../../converter/graph/gml/GmlParser";
-import { Layout } from "../../components/layout/Layout";
 
 const MaxCut: NextPage = () => {
   const [graphData, setGraphData] = useState<any>(null);

--- a/src/pages/solve/QUBO.tsx
+++ b/src/pages/solve/QUBO.tsx
@@ -1,10 +1,10 @@
-import Head from "next/head";
-import React, { useState } from "react";
+import { Code, Divider, Heading, Spacer, Text } from "@chakra-ui/react";
 import type { NextPage } from "next";
-import { TextInputMask } from "../../components/solvers/TextInputMask";
-import { ProgressHandler } from "../../components/solvers/ProgressHandler";
-import { Text, Divider, Heading, Spacer, Code } from "@chakra-ui/react";
+import Head from "next/head";
+import { useState } from "react";
 import { Layout } from "../../components/layout/Layout";
+import { ProgressHandler } from "../../components/solvers/ProgressHandler";
+import { TextInputMask } from "../../components/solvers/TextInputMask";
 
 const QUBO: NextPage = () => {
   const [quboTerm, setQuboTerm] = useState("");

--- a/src/pages/solve/SAT.tsx
+++ b/src/pages/solve/SAT.tsx
@@ -1,14 +1,13 @@
-import Head from "next/head";
-import React, { useState } from "react";
+import { Divider, Heading, Spacer, Text } from "@chakra-ui/react";
 import type { NextPage } from "next";
-import { TextArea } from "../../components/solvers/SAT/TextArea";
-import { ProgressHandler } from "../../components/solvers/ProgressHandler";
-import { Text, Divider, Heading, Spacer } from "@chakra-ui/react";
-import { DimacsParser } from "../../converter/dimacs/DimacsParser";
-import { LogicalExpressionParser } from "../../converter/dimacs/LogicalExpressionParser";
+import Head from "next/head";
+import { useState } from "react";
+import { baseUrl } from "../../api/ToolboxAPI";
 import { Layout } from "../../components/layout/Layout";
 import { EditorControls } from "../../components/solvers/EditorControls";
-import { baseUrl } from "../../api/ToolboxAPI";
+import { ProgressHandler } from "../../components/solvers/ProgressHandler";
+import { TextArea } from "../../components/solvers/SAT/TextArea";
+import { LogicalExpressionParser } from "../../converter/dimacs/LogicalExpressionParser";
 
 const SAT: NextPage = () => {
   const logicalExpressionParser = new LogicalExpressionParser();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5107,6 +5107,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier-plugin-organize-imports@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.4.tgz#77967f69d335e9c8e6e5d224074609309c62845e"
+  integrity sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==
+
 prettier@2.8.8:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"


### PR DESCRIPTION
This PR adds a plugin for prettier (our linter and formatter) that automatically organizes import statements (i.e., removing unused imports, ordering imports). It will also make prettier detect unorganized imports.