### PR TITLE
fix: fixed redundant dash in problem type

### DIFF
--- a/src/pages/solve/MaterialSimulation.tsx
+++ b/src/pages/solve/MaterialSimulation.tsx
@@ -18,14 +18,14 @@ const MaterialSimulation: NextPage = () => {
       </Text>
 
       <TextInputMask
-        problemTypeId="material-simulation"
+        problemTypeId="materialsimulation"
         text={molecule}
         setText={setMolecule}
         textPlaceholder="Enter your molecule to simulate, in XYZ format, units in angstroms."
       />
 
       <SolverConfiguration
-        problemTypeId="material-simulation"
+        problemTypeId="materialsimulation"
         problemInput={molecule}
       />
     </Layout>


### PR DESCRIPTION
there was an additional, redundant dash in the solve page for material simulations, resulting in communication to the backend not working