### PR TITLE
fix: passing api url in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ ENV NODE_ENV=production
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
+# Pass in NEXT_PUBLIC_API_BASE_URL from Docker build args
+# TODO: add MSS args later...
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+
 # Copy source and build
 COPY . .
 RUN yarn build


### PR DESCRIPTION
The newly added dockerfile causes issues on the ProvideQ server. The frontend can not fetch from the backend because the url is not passed correctly. This should fix the issue,